### PR TITLE
Fix per-part grammar checks for identifiers

### DIFF
--- a/protected/controllers/MistakeController.php
+++ b/protected/controllers/MistakeController.php
@@ -65,12 +65,11 @@ class MistakeController extends CController {
 			function($words) use ($pspells, $spellings) {
 				$mistakes = array();
 				foreach ($words[0] as $word) {
-					foreach (
-						$this->findMisspelledParts($pspells, $spellings, $word[0])
-						as $part
-					) {
-						$part[1] += $word[1];
-						$mistakes[] = $part;
+					$misspelled_parts =
+						$this->findMisspelledParts($pspells, $spellings, $word[0]);
+					foreach ($misspelled_parts as $misspelled_part) {
+						$misspelled_part[1] += $word[1];
+						$mistakes[] = $misspelled_part;
 					}
 				}
 
@@ -138,8 +137,7 @@ class MistakeController extends CController {
 	private static $pspell_languages = array('ru', 'en_US');
 
 	private function collectPointList($pspells) {
-		$points = Yii::app()
-			->db
+		$points = Yii::app()->db
 			->createCommand()
 			->from('{{points}}')
 			->where('text != ""')
@@ -152,16 +150,18 @@ class MistakeController extends CController {
 				$point['text'] = preg_replace_callback(
 					Spelling::WORD_PATTERN,
 					function($matches) use ($pspells, $spellings, &$counter) {
-						$result = '';
 						$word = $matches[0];
+						$misspelled_parts =
+							$this->findMisspelledParts($pspells, $spellings, $word);
+
+						$result = '';
 						$position = 0;
-						foreach (
-							$this->findMisspelledParts($pspells, $spellings, $word)
-							as $part
-						) {
-							$result .= substr($word, $position, $part[1] - $position);
+						foreach ($misspelled_parts as $misspelled_part) {
+							$counter++;
+
 							$result .=
-								'<mark>' . $part[0] . '</mark>'
+								substr($word, $position, $misspelled_part[1] - $position)
+								. '<mark>' . $misspelled_part[0] . '</mark>'
 								. '<button '
 									. 'class = "'
 										. 'btn '
@@ -169,22 +169,16 @@ class MistakeController extends CController {
 										. 'btn-xs '
 										. 'blue-button '
 										. 'add-word-button'
-									.'" '
-									. 'data-word = "'
-										. CHtml::encode($part[0])
 									. '" '
+									. 'data-word = "' . CHtml::encode($misspelled_part[0]) . '" '
 									. 'title = "Добавить в словарь">'
-									. '<span '
-										. 'class = "glyphicon glyphicon-plus">'
-									. '</span>'
+									. '<span class = "glyphicon glyphicon-plus"></span>'
 								. '</button>';
 
-							$counter++;
-							$position = $part[1] + strlen($part[0]);
+							$position = $misspelled_part[1] + strlen($misspelled_part[0]);
 						}
-						$result .= substr($word, $position);
 
-						return $result;
+						return $result . substr($word, $position);
 					},
 					$point['text']
 				);
@@ -260,6 +254,7 @@ class MistakeController extends CController {
 			-1,
 			PREG_SPLIT_OFFSET_CAPTURE
 		);
+
 		$misspelled_parts = array();
 		foreach ($sub_words as $sub_word) {
 			if (in_array(mb_strtolower($sub_word[0], 'utf-8'), $spellings)) {

--- a/protected/controllers/MistakeController.php
+++ b/protected/controllers/MistakeController.php
@@ -63,12 +63,18 @@ class MistakeController extends CController {
 		$spellings = $this->getSpellings();
 		$mistake_lines = array_map(
 			function($words) use ($pspells, $spellings) {
-				return array_filter(
-					$words[0],
-					function($word) use ($pspells, $spellings) {
-						return !$this->checkWord($pspells, $spellings, $word[0]);
+				$mistakes = array();
+				foreach ($words[0] as $word) {
+					foreach (
+						$this->findMisspelledParts($pspells, $spellings, $word[0])
+						as $part
+					) {
+						$part[1] += $word[1];
+						$mistakes[] = $part;
 					}
-				);
+				}
+
+				return $mistakes;
 			},
 			$word_lines
 		);
@@ -148,11 +154,14 @@ class MistakeController extends CController {
 					function($matches) use ($pspells, $spellings, &$counter) {
 						$result = '';
 						$word = $matches[0];
-						if ($this->checkWord($pspells, $spellings, $word)) {
-							$result = $word;
-						} else {
-							$result =
-								'<mark>' . $word . '</mark>'
+						$position = 0;
+						foreach (
+							$this->findMisspelledParts($pspells, $spellings, $word)
+							as $part
+						) {
+							$result .= substr($word, $position, $part[1] - $position);
+							$result .=
+								'<mark>' . $part[0] . '</mark>'
 								. '<button '
 									. 'class = "'
 										. 'btn '
@@ -162,7 +171,7 @@ class MistakeController extends CController {
 										. 'add-word-button'
 									.'" '
 									. 'data-word = "'
-										. CHtml::encode($word)
+										. CHtml::encode($part[0])
 									. '" '
 									. 'title = "Добавить в словарь">'
 									. '<span '
@@ -171,7 +180,9 @@ class MistakeController extends CController {
 								. '</button>';
 
 							$counter++;
+							$position = $part[1] + strlen($part[0]);
 						}
+						$result .= substr($word, $position);
 
 						return $result;
 					},
@@ -233,29 +244,41 @@ class MistakeController extends CController {
 		return $pspells;
 	}
 
-	private function checkWord($pspells, $spellings, $word) {
+	private function findMisspelledParts($pspells, $spellings, $word) {
 		if (in_array(mb_strtolower($word, 'utf-8'), $spellings)) {
-			return true;
+			return array();
 		}
 
 		// split words written in camel case into separate sub-words
 		// (https://stackoverflow.com/a/7729790)
-		$subWords = preg_split(
+		$sub_words = preg_split(
 			'/
 				(?: (?<=[a-z]) (?=[A-Z]) ) # split "fooFoo" into ["foo", "Foo"]
 				| (?: (?<=[A-Z]) (?=[A-Z][a-z]) ) # split "FOOFoo" into ["FOO", "Foo"]
 			/x',
-			$word
+			$word,
+			-1,
+			PREG_SPLIT_OFFSET_CAPTURE
 		);
-		foreach ($subWords as $subWord) {
+		$misspelled_parts = array();
+		foreach ($sub_words as $sub_word) {
+			if (in_array(mb_strtolower($sub_word[0], 'utf-8'), $spellings)) {
+				continue;
+			}
+
+			$correct = false;
 			foreach ($pspells as $pspell) {
-				if (pspell_check($pspell, $subWord)) {
-					return true;
+				if (pspell_check($pspell, $sub_word[0])) {
+					$correct = true;
+					break;
 				}
+			}
+			if (!$correct) {
+				$misspelled_parts[] = $sub_word;
 			}
 		}
 
-		return false;
+		return $misspelled_parts;
 	}
 
 	private function getSpellings() {

--- a/protected/controllers/MistakeController.php
+++ b/protected/controllers/MistakeController.php
@@ -54,7 +54,7 @@ class MistakeController extends CController {
 					throw new CHttpException(500, 'Ошибка парсинга строки текста.');
 				}
 
-				return $matches;
+				return $matches[0];
 			},
 			$lines
 		);
@@ -62,9 +62,9 @@ class MistakeController extends CController {
 		$pspells = $this->initPspells(self::$pspell_languages);
 		$spellings = $this->getSpellings();
 		$mistake_lines = array_map(
-			function($words) use ($pspells, $spellings) {
+			function($word_line) use ($pspells, $spellings) {
 				$mistakes = array();
-				foreach ($words[0] as $word) {
+				foreach ($word_line as $word) {
 					$misspelled_parts =
 						$this->findMisspelledParts($pspells, $spellings, $word[0]);
 					foreach ($misspelled_parts as $misspelled_part) {
@@ -81,25 +81,19 @@ class MistakeController extends CController {
 		$line_counter = 0;
 		$mistakes = array();
 		array_map(
-			function($words) use (&$mistakes, $lines, &$line_counter) {
+			function($mistake_line) use (&$mistakes, $lines, &$line_counter) {
 				array_map(
-					function($word) use (&$mistakes, $lines, $line_counter) {
-						$offset = mb_strlen(
-							substr($lines[$line_counter], 0, $word[1]),
-							'utf-8'
-						);
+					function($misspelled_part) use (&$mistakes, $lines, $line_counter) {
+						$mistake_prefix =
+							substr($lines[$line_counter], 0, $misspelled_part[1]);
+						$start = mb_strlen($mistake_prefix, 'utf-8');
+						$end = $start + mb_strlen($misspelled_part[0], 'utf-8');
 						$mistakes[] = array(
-							'start' => array(
-								'line' => $line_counter,
-								'offset' => $offset
-							),
-							'end' => array(
-								'line' => $line_counter,
-								'offset' => $offset + mb_strlen($word[0], 'utf-8')
-							)
+							'start' => array('line' => $line_counter, 'offset' => $start),
+							'end' => array('line' => $line_counter, 'offset' => $end)
 						);
 					},
-					$words
+					$mistake_line
 				);
 
 				$line_counter++;


### PR DESCRIPTION
### Motivation

- The identifier spellchecker treated an entire camel-case identifier as correct if any part was correct, and when broken it highlighted the whole identifier instead of only the incorrect parts.
- The change aims to perform per-part checks and produce correct editor offsets so only misspelled identifier parts are reported and can be added individually to the dictionary.

### Description

- Added `findMisspelledParts($pspells, $spellings, $word)` that splits identifiers with `PREG_SPLIT_OFFSET_CAPTURE` and returns only misspelled parts with offsets instead of a single boolean check.
- Updated the check flow to aggregate per-part results and normalize offsets by adding the regex match base offset before producing diagnostics in `actionCheck`/`$mistake_lines`.
- Updated `collectPointList` rendering to highlight only misspelled parts and attach the `add-word-button` to each part using `data-word = CHtml::encode($part[0])`, while preserving UTF-8-aware substring/length calculations.
- Preserved existing pspell/dictionary logic and integrated per-part custom-spelling support so whole-identifier whitelist entries still work while enabling part-level dictionary actions.

### Testing

- Ran `php -l protected/controllers/MistakeController.php` to verify there are no syntax errors, and it succeeded.
- Ran `git diff --check` to ensure no whitespace/patch issues, and it succeeded.
- Executed a reflection-based PHP script that mocks `pspell_check` and verifies mixed valid/invalid camel-case parts, acronym boundaries, per-part custom spellings, and whole-identifier custom spellings; the checks passed.
- Verified the changed code produces correct UTF-8 offsets and per-part highlights during the simulated runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6ad4cab784832bb84612eb4720c2d8)

Issue: #270